### PR TITLE
Generate SMT2 expressions for digital circuits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ targetCompatibility = 1.8
 
 group = "org.manifold"
 // name = "manifold-backend-digital"
-version = '0.4.0-SNAPSHOT'
+version = '0.5.0-SNAPSHOT'
 
 mainClassName = "org.manifold.compiler.back.digital.DigitalBackend"
 

--- a/src/main/java/org/manifold/compiler/back/digital/DigitalBackend.java
+++ b/src/main/java/org/manifold/compiler/back/digital/DigitalBackend.java
@@ -29,6 +29,7 @@ public class DigitalBackend implements Backend {
   
   public enum TargetHDL {
     VHDL,
+    SMT2,
   };
 
   private TargetHDL targetHDL = null;
@@ -37,7 +38,7 @@ public class DigitalBackend implements Backend {
   }
 
   private void createOptionTargetHDL(Options options) {
-    Option hdl = new Option("h", "hdl", true, "target HDL type (vhdl)");
+    Option hdl = new Option("h", "hdl", true, "target HDL type (vhdl, smt2)");
     options.addOption(hdl);
   }
 
@@ -50,6 +51,8 @@ public class DigitalBackend implements Backend {
       hdl = hdl.toLowerCase();
       if (hdl.equals("vhdl")) {
         targetHDL = TargetHDL.VHDL;
+      } else if (hdl.equals("smt2")) {
+        targetHDL = TargetHDL.SMT2;
       } else {
         throw new OptionError("target HDL '" + hdl + "' not recognized");
       }
@@ -177,6 +180,19 @@ public class DigitalBackend implements Backend {
           }
           vhdlGen.generateOutputProducts();
         } // end case VHDL
+          break;
+        case SMT2: {
+          SMT2CodeGenerator smtgen = new SMT2CodeGenerator(
+              schematic, netlist, typeTable);
+          if (outputDirectory != null) {
+            smtgen.setOutputDirectory(outputDirectory);
+          }
+          if (noChecks) {
+            smtgen.setRunChecks(false);
+          }
+          smtgen.generateOutputProducts();
+        } // end case SMT2
+          break;
     }
   }
 

--- a/src/main/java/org/manifold/compiler/back/digital/PrimitiveTypeTable.java
+++ b/src/main/java/org/manifold/compiler/back/digital/PrimitiveTypeTable.java
@@ -1,0 +1,72 @@
+package org.manifold.compiler.back.digital;
+
+import org.manifold.compiler.NodeTypeValue;
+import org.manifold.compiler.PortTypeValue;
+import org.manifold.compiler.UndeclaredIdentifierException;
+import org.manifold.compiler.middle.Schematic;
+
+public class PrimitiveTypeTable {
+
+  private PortTypeValue inputPortType = null;
+  private PortTypeValue outputPortType = null;
+  
+  private NodeTypeValue inputPinType = null;
+  private NodeTypeValue outputPinType = null;
+
+  private NodeTypeValue registerType = null;
+  private NodeTypeValue andType = null;
+  private NodeTypeValue orType = null;
+  private NodeTypeValue notType = null;
+  
+  public PortTypeValue getInputPortType() {
+    return inputPortType;
+  }
+
+  public PortTypeValue getOutputPortType() {
+    return outputPortType;
+  }
+
+  public NodeTypeValue getInputPinType() {
+    return inputPinType;
+  }
+
+  public NodeTypeValue getOutputPinType() {
+    return outputPinType;
+  }
+
+  public NodeTypeValue getRegisterType() {
+    return registerType;
+  }
+
+  public NodeTypeValue getAndType() {
+    return andType;
+  }
+
+  public NodeTypeValue getOrType() {
+    return orType;
+  }
+
+  public NodeTypeValue getNotType() {
+    return notType;
+  }
+  
+  public PrimitiveTypeTable(Schematic schematic) {
+    // get information from the schematic about which node types to use
+    try {
+      inputPortType = schematic.getPortType("digitalIn");
+      outputPortType = schematic.getPortType("digitalOut");
+      inputPinType = schematic.getNodeType("inputPin");
+      outputPinType = schematic.getNodeType("outputPin");
+      registerType = schematic.getNodeType("register");
+      andType = schematic.getNodeType("and");
+      orType = schematic.getNodeType("or");
+      notType = schematic.getNodeType("not");
+    } catch (UndeclaredIdentifierException e) {
+      throw new CodeGenerationError(
+          "could not find required digital design type '"
+          + e.getIdentifier() + "'; schematic version mismatch or "
+          + " not a digital schematic");
+    }
+  }
+  
+}

--- a/src/main/java/org/manifold/compiler/back/digital/SMT2CodeGenerator.java
+++ b/src/main/java/org/manifold/compiler/back/digital/SMT2CodeGenerator.java
@@ -230,8 +230,8 @@ public class SMT2CodeGenerator {
   }
   
   public void generateOutputProducts() {
-    if (numberOfStates < 1) {
-      err("invalid number of states specified; must be at least 1");
+    if (numberOfStates < 0) {
+      err("invalid number of states specified; must be non-negative");
     }
     
     String entityName = schematic.getName();

--- a/src/main/java/org/manifold/compiler/back/digital/SMT2CodeGenerator.java
+++ b/src/main/java/org/manifold/compiler/back/digital/SMT2CodeGenerator.java
@@ -1,6 +1,8 @@
 package org.manifold.compiler.back.digital;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
@@ -240,7 +242,8 @@ public class SMT2CodeGenerator {
     File outfile = new File(outpath.toString());
     log.info("Generating " + filename);
     
-    try (PrintWriter writer = new PrintWriter(outfile, "US-ASCII");) {
+    try (PrintWriter writer = new PrintWriter(new BufferedWriter(
+        new FileWriter(outfile)));) {
       // SMT2 logic header: QF_ABV
       // TODO if no component is modelled as an array, emit QF_BV
       // TODO check to make sure all nets are driven

--- a/src/main/java/org/manifold/compiler/back/digital/SMT2CodeGenerator.java
+++ b/src/main/java/org/manifold/compiler/back/digital/SMT2CodeGenerator.java
@@ -1,0 +1,299 @@
+package org.manifold.compiler.back.digital;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.manifold.compiler.BooleanValue;
+import org.manifold.compiler.NodeValue;
+import org.manifold.compiler.PortValue;
+import org.manifold.compiler.UndeclaredAttributeException;
+import org.manifold.compiler.UndeclaredIdentifierException;
+import org.manifold.compiler.back.digital.smt2.Bitstring;
+import org.manifold.compiler.back.digital.smt2.QFABV;
+import org.manifold.compiler.back.digital.smt2.SExpression;
+import org.manifold.compiler.back.digital.smt2.Symbol;
+import org.manifold.compiler.middle.Schematic;
+
+public class SMT2CodeGenerator {
+  private static Logger log = LogManager.getLogger("SMT2CodeGenerator");
+
+  private Schematic schematic;
+  private Netlist netlist;
+  private PrimitiveTypeTable typeTable;
+  
+  private String outputDirectory;
+  public void setOutputDirectory(String dir) {
+    this.outputDirectory = dir;
+  }
+  
+  private boolean runChecks = true;
+  public void setRunChecks(boolean run) {
+    this.runChecks = run;
+  }
+  
+  // valid states are 0..numberOfStates inclusive
+  private int numberOfStates = 200;
+  public void setNumberOfStates(int n) {
+    this.numberOfStates = n;
+  }
+  
+  private List<SExpression> declarations;
+  private List<SExpression> assertions;
+  
+  public SMT2CodeGenerator(Schematic schematic, Netlist netlist,
+      PrimitiveTypeTable typeTable) {
+    this.schematic = schematic;
+    this.netlist = netlist;
+    this.typeTable = typeTable;
+    // by default, output to current working directory
+    this.outputDirectory = Paths.get("").toAbsolutePath().toString();
+    
+    this.declarations = new LinkedList<SExpression>();
+    this.assertions = new LinkedList<SExpression>();
+  }
+  
+  private void err(String message) {
+    throw new CodeGenerationError(message);
+  }
+  
+  private void generateInputPin(String nodeName, NodeValue node) 
+      throws UndeclaredIdentifierException {
+    // find out what net we drive
+    PortValue inputPort = node.getPort("out");
+    Net inputNet = netlist.getConnectedNet(inputPort);
+    String netName = inputNet.getName();
+    for (int i = 0; i <= numberOfStates; ++i) {
+      Symbol symInput = QFABV.getStateVariable(nodeName, i);
+      Symbol symNet = QFABV.getStateVariable(netName, i);
+      // declare state variables
+      declarations.add(QFABV.declareBitVector(symInput, 1));
+      declarations.add(QFABV.declareBitVector(symNet, 1));
+      // the input drives the net on every timestep
+      assertions.add(QFABV.assertThat(QFABV.equal(symInput, symNet)));
+    }
+  }
+  
+  private void generateOutputPin(String nodeName, NodeValue node) 
+      throws UndeclaredIdentifierException {
+    // find out what net drives the input
+    PortValue outputPort = node.getPort("in");
+    Net outputNet = netlist.getConnectedNet(outputPort);
+    String netName = outputNet.getName();
+    for (int i = 0; i <= numberOfStates; ++i) {
+      Symbol symOutput = QFABV.getStateVariable(nodeName, i);
+      Symbol symNet = QFABV.getStateVariable(netName, i);
+      // declare state variables (outputs only)
+      declarations.add(QFABV.declareBitVector(symOutput, 1));
+      // the input drives the net on every timestep
+      assertions.add(QFABV.assertThat(QFABV.equal(symOutput, symNet)));
+    }
+  }
+  
+  private void generateAndGate(String nodeName, NodeValue node) 
+      throws UndeclaredIdentifierException {
+    // out = in0 AND in1
+    PortValue in0Port = node.getPort("in0");
+    PortValue in1Port = node.getPort("in1");
+    PortValue outPort = node.getPort("out");
+    
+    Net in0Net = netlist.getConnectedNet(in0Port);
+    Net in1Net = netlist.getConnectedNet(in1Port);
+    Net outNet = netlist.getConnectedNet(outPort);
+    
+    String in0NetName = in0Net.getName();
+    String in1NetName = in1Net.getName();
+    String outNetName = outNet.getName();
+    
+    for (int i = 0; i <= numberOfStates; ++i) {
+      Symbol symIn0 = QFABV.getStateVariable(in0NetName, i);
+      Symbol symIn1 = QFABV.getStateVariable(in1NetName, i);
+      Symbol symOut = QFABV.getStateVariable(outNetName, i);
+      // declare net for output
+      declarations.add(QFABV.declareBitVector(symOut, 1));
+      assertions.add(QFABV.assertThat(QFABV.equal(
+          symOut, QFABV.and(symIn0, symIn1))));
+    }
+  }
+  
+  private void generateOrGate(String nodeName, NodeValue node) 
+      throws UndeclaredIdentifierException {
+    // out = in0 OR in1
+    PortValue in0Port = node.getPort("in0");
+    PortValue in1Port = node.getPort("in1");
+    PortValue outPort = node.getPort("out");
+    
+    Net in0Net = netlist.getConnectedNet(in0Port);
+    Net in1Net = netlist.getConnectedNet(in1Port);
+    Net outNet = netlist.getConnectedNet(outPort);
+    
+    String in0NetName = in0Net.getName();
+    String in1NetName = in1Net.getName();
+    String outNetName = outNet.getName();
+    
+    for (int i = 0; i <= numberOfStates; ++i) {
+      Symbol symIn0 = QFABV.getStateVariable(in0NetName, i);
+      Symbol symIn1 = QFABV.getStateVariable(in1NetName, i);
+      Symbol symOut = QFABV.getStateVariable(outNetName, i);
+      // declare net for output
+      declarations.add(QFABV.declareBitVector(symOut, 1));
+      assertions.add(QFABV.assertThat(QFABV.equal(
+          symOut, QFABV.or(symIn0, symIn1))));
+    }
+  }
+  
+  private void generateNotGate(String nodeName, NodeValue node) 
+      throws UndeclaredIdentifierException {
+    // out = NOT in
+    PortValue inPort = node.getPort("in");
+    PortValue outPort = node.getPort("out");
+    
+    Net inNet = netlist.getConnectedNet(inPort);
+    Net outNet = netlist.getConnectedNet(outPort);
+    
+    String inNetName = inNet.getName();
+    String outNetName = outNet.getName();
+    
+    for (int i = 0; i <= numberOfStates; ++i) {
+      Symbol symIn = QFABV.getStateVariable(inNetName, i);
+      Symbol symOut = QFABV.getStateVariable(outNetName, i);
+      // declare net for output
+      declarations.add(QFABV.declareBitVector(symOut, 1));
+      assertions.add(QFABV.assertThat(QFABV.equal(
+          symOut, QFABV.not(symIn))));
+    }
+  }
+  
+  private void generateRegister(String nodeName, NodeValue node) 
+      throws UndeclaredIdentifierException, UndeclaredAttributeException {
+    // ports: in, out, reset
+    // attributes: initialValue, resetActiveHigh
+    PortValue inPort = node.getPort("in");
+    PortValue outPort = node.getPort("out");
+    PortValue resetPort = node.getPort("reset");
+    
+    Net inNet = netlist.getConnectedNet(inPort);
+    Net outNet = netlist.getConnectedNet(outPort);
+    Net resetNet = netlist.getConnectedNet(resetPort);
+    
+    String inNetName = inNet.getName();
+    String outNetName = outNet.getName();
+    String resetNetName = resetNet.getName();
+    
+    boolean initialValue = ((BooleanValue) node
+        .getAttribute("initialValue")).toBoolean();
+    boolean resetActiveHigh = ((BooleanValue) node
+        .getAttribute("resetActiveHigh")).toBoolean();
+    
+    // t=0: define out net, drive output(t) = initial value
+    {
+      Symbol symOut = QFABV.getStateVariable(outNetName, 0);
+      declarations.add(QFABV.declareBitVector(symOut, 1));
+      if (initialValue) {
+        assertions.add(QFABV.assertBitOne(symOut));
+      } else {
+        assertions.add(QFABV.assertBitZero(symOut));
+      }
+    }
+    // t>0: define out net
+    // t>0: if reset(t-1) asserted, drive output(t) = initial value;
+    //      else, drive output(t) = input(t-1)
+    for (int i = 1; i <= numberOfStates; ++i) {
+      Symbol symIn = QFABV.getStateVariable(inNetName, i - 1);
+      Symbol symReset = QFABV.getStateVariable(resetNetName, i - 1);
+      Symbol symOut = QFABV.getStateVariable(outNetName, i);
+      
+      declarations.add(QFABV.declareBitVector(symOut, 1));
+      SExpression resetActive;
+      if (resetActiveHigh) {
+        resetActive = new Bitstring("1");
+      } else {
+        resetActive = new Bitstring("0");
+      }
+      SExpression init;
+      if (initialValue) {
+        init = new Bitstring("1");
+      } else {
+        init = new Bitstring("0");
+      }
+      
+      assertions.add(QFABV.equal(symOut,
+          QFABV.conditional(QFABV.equal(symReset, resetActive), init, symIn)));
+    }
+  }
+  
+  public void generateOutputProducts() {
+    if (numberOfStates < 1) {
+      err("invalid number of states specified; must be at least 1");
+    }
+    
+    String entityName = schematic.getName();
+    String filename = entityName + ".smt2";
+    Path outpath = Paths.get(outputDirectory + File.separator + filename);
+    File outfile = new File(outpath.toString());
+    log.info("Generating " + filename);
+    
+    try (PrintWriter writer = new PrintWriter(outfile, "US-ASCII");) {
+      // SMT2 logic header: QF_ABV
+      // TODO if no component is modelled as an array, emit QF_BV
+      // TODO check to make sure all nets are driven
+      // TODO check that all resets are synchronous
+      // TODO check that all registers clock on the same edge
+      // TODO check that all registers are in the same clock domain
+      writer.println("(set-logic QF_ABV)");
+      writer.println("(set-info :smt-lib-version 2.0)");
+      // for each node, populate two sets:
+      // * declarations: all outputs declared by this node
+      // * assertions: all equations that model this node
+      // note that we end up with 'numberOfStates'+1 copies of
+      // each declaration (which each generator creates on its own)
+      try {
+        for (Entry<String, NodeValue> entry : schematic.getNodes().entrySet()) {
+          String nodeName = entry.getKey();
+          NodeValue node = entry.getValue();
+          if (node.getType().equals(typeTable.getInputPinType())) {
+            generateInputPin(nodeName, node);
+          } else if (node.getType().equals(typeTable.getOutputPinType())) {
+            generateOutputPin(nodeName, node);
+          } else if (node.getType().equals(typeTable.getAndType())) {
+            generateAndGate(nodeName, node);
+          } else if (node.getType().equals(typeTable.getOrType())) {
+            generateOrGate(nodeName, node);
+          } else if (node.getType().equals(typeTable.getNotType())) {
+            generateNotGate(nodeName, node);
+          } else if (node.getType().equals(typeTable.getRegisterType())) {
+            generateRegister(nodeName, node);
+          } else {
+            err("node " + nodeName + " has unknown node type");
+          }
+        }
+      } catch (UndeclaredIdentifierException | UndeclaredAttributeException e) {
+        err(e.getMessage());
+      }
+      
+      // then write out all generated expressions, starting with declarations
+      // followed by assertions
+      for (SExpression expr : declarations) {
+        expr.write(writer);
+        writer.println();
+      }
+      for (SExpression expr : assertions) {
+        expr.write(writer);
+        writer.println();
+      }
+      
+    } catch (IOException e) {
+      err(e.getMessage());
+    }
+    
+    log.info("Finished generating " + filename);
+  }
+  
+}

--- a/src/main/java/org/manifold/compiler/back/digital/VHDLCodeGenerator.java
+++ b/src/main/java/org/manifold/compiler/back/digital/VHDLCodeGenerator.java
@@ -86,6 +86,7 @@ public class VHDLCodeGenerator {
   private List<Check> buildStandardChecks() {
     List<Check> checks = new ArrayList<Check>();
     checks.add(new NoMultipleDriversCheck(schematic, netlist));
+    checks.add(new NoUnconnectedInputsCheck(schematic, netlist));
     return checks;
   }
   

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/Bitstring.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/Bitstring.java
@@ -1,0 +1,21 @@
+package org.manifold.compiler.back.digital.smt2;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class Bitstring extends SExpression {
+
+  private final String bitstring;
+  
+  public Bitstring(String bitstring) {
+    this.bitstring = bitstring;
+    // TODO verify well-formed bitstring
+  }
+  
+  @Override
+  public void write(Writer writer) throws IOException {
+    writer.write("#b");
+    writer.write(bitstring);
+  }
+
+}

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/Numeral.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/Numeral.java
@@ -1,0 +1,33 @@
+package org.manifold.compiler.back.digital.smt2;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class Numeral extends SExpression {
+  private long value;
+  public long getValue() {
+    return this.value;
+  }
+  
+  public Numeral(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Numeral)) {
+      return false;
+    }
+    Numeral that = (Numeral) other;
+    return (this.getValue() == that.getValue());
+  }
+  
+  @Override
+  public void write(Writer writer) throws IOException {
+    writer.write(Long.toString(getValue()));
+  }
+
+}

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/ParenList.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/ParenList.java
@@ -1,0 +1,44 @@
+package org.manifold.compiler.back.digital.smt2;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+public class ParenList extends SExpression {
+
+  private List<SExpression> exprs = new ArrayList<>();
+  public List<SExpression> getExprs() {
+    return ImmutableList.copyOf(exprs);
+  }
+  
+  public ParenList() { }
+  
+  public ParenList(SExpression expr) {
+    this.exprs.add(expr);
+  }
+  
+  public ParenList(SExpression exprs[]) {
+    for (SExpression expr : exprs) {
+      this.exprs.add(expr);
+    }
+  }
+  
+  public ParenList(List<SExpression> exprs) {
+    this.exprs.addAll(exprs);
+  }
+  
+  @Override
+  public void write(Writer writer) throws IOException {
+    writer.write('(');
+    for (SExpression expr : exprs) {
+      writer.write(' ');
+      expr.write(writer);
+    }
+    writer.write(' ');
+    writer.write(')');
+  }
+
+}

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/ParenList.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/ParenList.java
@@ -16,11 +16,7 @@ public class ParenList extends SExpression {
   
   public ParenList() { }
   
-  public ParenList(SExpression expr) {
-    this.exprs.add(expr);
-  }
-  
-  public ParenList(SExpression exprs[]) {
+  public ParenList(SExpression... exprs) {
     for (SExpression expr : exprs) {
       this.exprs.add(expr);
     }

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/QFABV.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/QFABV.java
@@ -1,0 +1,81 @@
+package org.manifold.compiler.back.digital.smt2;
+
+
+// Code generation helpers for SMT2 QF_ABV expressions
+public class QFABV {
+
+  public static Symbol getStateVariable(String name, int timestep) {
+    String suffix = "__" + Integer.toString(timestep);
+    return new Symbol(name + suffix);
+  }
+  
+  public static SExpression declareBitVector(Symbol sym, long width) {
+    SExpression exprs[] = new SExpression[] {
+        new Symbol("declare-fun"),
+        sym,
+        new ParenList(),
+        new ParenList(new SExpression[]{
+            new Symbol("_"), new Symbol("BitVec"), new Numeral(width)})
+        };
+    return new ParenList(exprs);
+  }
+  
+  private static SExpression infix(SExpression e1, String op, SExpression e2) {
+    SExpression exprs[] = new SExpression[] {
+        new Symbol(op),
+        e1,
+        e2
+    };
+    return new ParenList(exprs);
+  }
+  
+  public static SExpression equal(SExpression e1, SExpression e2) {
+    return infix(e1, "=", e2);
+  }
+  
+  public static SExpression assertThat(SExpression term) {
+    SExpression assertExprs[] = new SExpression[] {
+        new Symbol("assert"),
+        term
+    };
+    return new ParenList(assertExprs);
+  }
+  
+  //(assert (= sym #b0))
+  public static SExpression assertBitZero(Symbol sym) {
+    return assertThat(equal(sym, new Bitstring("0")));
+  }
+  
+  // (assert (= sym #b1))
+  public static SExpression assertBitOne(Symbol sym) {
+    return assertThat(equal(sym, new Bitstring("1")));
+  }
+  
+  public static SExpression and(SExpression e1, SExpression e2) {
+    return infix(e1, "bvand", e2);
+  }
+  
+  public static SExpression or(SExpression e1, SExpression e2) {
+    return infix(e1, "bvor", e2);
+  }
+  
+  public static SExpression not(SExpression e) {
+    SExpression exprs[] = new SExpression[] {
+        new Symbol("bvnot"),
+        e
+    };
+    return new ParenList(exprs);
+  }
+  
+  public static SExpression conditional(
+      SExpression cond, SExpression t, SExpression f) {
+    SExpression exprs[] = new SExpression[] {
+        new Symbol("ite"), // "if-then-else"
+        cond,
+        t,
+        f
+    };
+    return new ParenList(exprs);
+  }
+  
+}

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/QFABV.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/QFABV.java
@@ -10,23 +10,17 @@ public class QFABV {
   }
   
   public static SExpression declareBitVector(Symbol sym, long width) {
-    SExpression exprs[] = new SExpression[] {
-        new Symbol("declare-fun"),
+    return new ParenList(new Symbol("declare-fun"),
         sym,
         new ParenList(),
-        new ParenList(new SExpression[]{
-            new Symbol("_"), new Symbol("BitVec"), new Numeral(width)})
-        };
-    return new ParenList(exprs);
+        new ParenList(new Symbol("_"), new Symbol("BitVec"), new Numeral(width)
+        ));
   }
   
   private static SExpression infix(SExpression e1, String op, SExpression e2) {
-    SExpression exprs[] = new SExpression[] {
-        new Symbol(op),
+    return new ParenList(new Symbol(op),
         e1,
-        e2
-    };
-    return new ParenList(exprs);
+        e2);
   }
   
   public static SExpression equal(SExpression e1, SExpression e2) {
@@ -34,11 +28,7 @@ public class QFABV {
   }
   
   public static SExpression assertThat(SExpression term) {
-    SExpression assertExprs[] = new SExpression[] {
-        new Symbol("assert"),
-        term
-    };
-    return new ParenList(assertExprs);
+    return new ParenList(new Symbol("assert"), term);
   }
   
   //(assert (= sym #b0))
@@ -60,22 +50,15 @@ public class QFABV {
   }
   
   public static SExpression not(SExpression e) {
-    SExpression exprs[] = new SExpression[] {
-        new Symbol("bvnot"),
-        e
-    };
-    return new ParenList(exprs);
+    return new ParenList(new Symbol("bvnot"), e);
   }
   
   public static SExpression conditional(
       SExpression cond, SExpression t, SExpression f) {
-    SExpression exprs[] = new SExpression[] {
-        new Symbol("ite"), // "if-then-else"
+    return new ParenList(new Symbol("ite"), // "if-then-else"
         cond,
         t,
-        f
-    };
-    return new ParenList(exprs);
+        f);
   }
   
 }

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/SExpression.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/SExpression.java
@@ -1,0 +1,21 @@
+package org.manifold.compiler.back.digital.smt2;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+public abstract class SExpression {
+  public abstract void write(Writer writer) throws IOException;
+  
+  @Override
+  public String toString() {
+    StringWriter sWrite = new StringWriter();
+    try {
+      write(sWrite);
+      return sWrite.toString();
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "could not convert s-expression to string: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/Symbol.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/Symbol.java
@@ -4,41 +4,12 @@ import java.io.IOException;
 import java.io.Writer;
 
 public class Symbol extends SExpression {
-  // TODO symbol names do not always need to be escaped
-  // so only add |s if it is absolutely necessary
-  
-  private String name;
+  private final String name;
   public String getName() {
     return name;
   }
   
-  private void validateName(String name) {
-    // A symbol is a any sequence of printable ASCII characters (including 
-    // space, tab, and line-breaking characters) except for the 
-    // backslash character \, that starts and ends with | 
-    // and does not otherwise contain |.
-    if (!name.startsWith("|")) {
-      throw new IllegalArgumentException("symbol must start with '|'");
-    }
-    if (!name.endsWith("|")) {
-      throw new IllegalArgumentException("symbol must end with '|'");
-    }
-    if (name.indexOf('\\') != -1) {
-      throw new IllegalArgumentException("symbol cannot contain '\\'");
-    }
-  }
-  
   public Symbol(String name) {
-    /*
-    // If the name isn't delimited by |s, add them.
-    if (!name.startsWith("|")) {
-      name = "|" + name;
-    }
-    if (!name.endsWith("|")) {
-      name = name + "|";
-    }
-    validateName(name);
-    */
     this.name = name;
   }
   

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/Symbol.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/Symbol.java
@@ -1,0 +1,65 @@
+package org.manifold.compiler.back.digital.smt2;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class Symbol extends SExpression {
+  // TODO symbol names do not always need to be escaped
+  // so only add |s if it is absolutely necessary
+  
+  private String name;
+  public String getName() {
+    return name;
+  }
+  
+  private void validateName(String name) {
+    // A symbol is a any sequence of printable ASCII characters (including 
+    // space, tab, and line-breaking characters) except for the 
+    // backslash character \, that starts and ends with | 
+    // and does not otherwise contain |.
+    if (!name.startsWith("|")) {
+      throw new IllegalArgumentException("symbol must start with '|'");
+    }
+    if (!name.endsWith("|")) {
+      throw new IllegalArgumentException("symbol must end with '|'");
+    }
+    if (name.indexOf('\\') != -1) {
+      throw new IllegalArgumentException("symbol cannot contain '\\'");
+    }
+  }
+  
+  public Symbol(String name) {
+    // If the name isn't delimited by |s, add them.
+    if (!name.startsWith("|")) {
+      name = "|" + name;
+    }
+    if (!name.endsWith("|")) {
+      name = name + "|";
+    }
+    validateName(name);
+    this.name = name;
+  }
+  
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof Symbol)) {
+      return false;
+    }
+    Symbol that = (Symbol) other;
+    return (this.getName().equals(that.getName()));
+  }
+  
+  @Override
+  public int hashCode() {
+    return getName().hashCode();
+  }
+
+  @Override
+  public void write(Writer writer) throws IOException {
+    writer.write(getName());
+  }
+  
+}

--- a/src/main/java/org/manifold/compiler/back/digital/smt2/Symbol.java
+++ b/src/main/java/org/manifold/compiler/back/digital/smt2/Symbol.java
@@ -29,6 +29,7 @@ public class Symbol extends SExpression {
   }
   
   public Symbol(String name) {
+    /*
     // If the name isn't delimited by |s, add them.
     if (!name.startsWith("|")) {
       name = "|" + name;
@@ -37,6 +38,7 @@ public class Symbol extends SExpression {
       name = name + "|";
     }
     validateName(name);
+    */
     this.name = name;
   }
   

--- a/src/test/java/org/manifold/compiler/back/TestSMT2CodeGenerator.java
+++ b/src/test/java/org/manifold/compiler/back/TestSMT2CodeGenerator.java
@@ -119,7 +119,7 @@ public class TestSMT2CodeGenerator {
       fail(x.getMessage());
     }
 
-    // check that "test.vhd" was generated
+    // check that "test.smt2" was generated
     boolean found = false;
     Path testSMT = null;
     for (Path file : outputFiles) {

--- a/src/test/java/org/manifold/compiler/back/TestSMT2CodeGenerator.java
+++ b/src/test/java/org/manifold/compiler/back/TestSMT2CodeGenerator.java
@@ -1,0 +1,173 @@
+package org.manifold.compiler.back;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryIteratorException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.PatternLayout;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.manifold.compiler.ConnectionValue;
+import org.manifold.compiler.NodeValue;
+import org.manifold.compiler.TypeMismatchException;
+import org.manifold.compiler.UndeclaredIdentifierException;
+import org.manifold.compiler.back.digital.Netlist;
+import org.manifold.compiler.back.digital.PrimitiveTypeTable;
+import org.manifold.compiler.back.digital.SMT2CodeGenerator;
+import org.manifold.compiler.middle.Schematic;
+import org.manifold.compiler.middle.SchematicException;
+
+public class TestSMT2CodeGenerator {
+
+  @BeforeClass
+  public static void setupClass() {
+    LogManager.getRootLogger().setLevel(Level.ALL);
+    PatternLayout layout = new PatternLayout(
+        "%d{ISO8601} [%t] %-5p %c %x - %m%n");
+    LogManager.getRootLogger().addAppender(
+        new ConsoleAppender(layout, ConsoleAppender.SYSTEM_ERR));
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    LogManager.getRootLogger().removeAllAppenders();
+  }
+  
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+  
+  private List<String> schematicToSMT2(Schematic schematic, int nStates) 
+      throws IOException, UndeclaredIdentifierException, TypeMismatchException {
+    Netlist netlist = new Netlist(schematic);
+    PrimitiveTypeTable typeTable = new PrimitiveTypeTable(schematic);
+    SMT2CodeGenerator codegen = new SMT2CodeGenerator(
+        schematic, netlist, typeTable);
+    codegen.setNumberOfStates(nStates);
+    File tempdir = folder.getRoot();
+    String temppath = tempdir.getAbsolutePath();
+    codegen.setOutputDirectory(temppath);
+    codegen.generateOutputProducts();
+
+    // open generated code
+    String testOutputFilename = temppath + "/" + schematic.getName() + ".smt2";
+    Path testOutputPath = Paths.get(testOutputFilename);
+    List<String> lines = Files.readAllLines(testOutputPath);
+    return lines;
+  }
+  
+  private int countMatches(List<String> block, String pattern){
+    Pattern p = Pattern.compile(pattern);
+    int matchCount = 0;
+    for (String target : block) {
+      Matcher mTarget = p.matcher(target);
+      if (mTarget.find()) {
+        ++matchCount;
+      }
+    }
+    return matchCount;
+  }
+  
+  @Test
+  public void testOutputProductPresent() throws SchematicException {
+    // Connect an input pin straight across to an output pin.
+    Schematic schematic = UtilSchematicConstruction
+        .instantiateSchematic("test");
+    NodeValue in0 = UtilSchematicConstruction.instantiateInputPin();
+    schematic.addNode("in0", in0);
+    NodeValue out0 = UtilSchematicConstruction.instantiateOutputPin();
+    schematic.addNode("out0", out0);
+    ConnectionValue in0ToOut0 = UtilSchematicConstruction.instantiateWire(
+        in0.getPort("out"), out0.getPort("in"));
+    schematic.addConnection("in0_to_out0", in0ToOut0);
+    
+    Netlist netlist = new Netlist(schematic);
+    PrimitiveTypeTable typeTable = new PrimitiveTypeTable(schematic);
+    
+    SMT2CodeGenerator codegen = new SMT2CodeGenerator(
+        schematic, netlist, typeTable);
+    File tempdir = folder.getRoot();
+    String temppath = tempdir.getAbsolutePath();
+    codegen.setOutputDirectory(temppath);
+    codegen.generateOutputProducts();
+
+    List<Path> outputFiles = new ArrayList<Path>();
+
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths
+        .get(temppath))) {
+      for (Path file : stream) {
+        outputFiles.add(file);
+      }
+    } catch (IOException | DirectoryIteratorException x) {
+      fail(x.getMessage());
+    }
+
+    // check that "test.vhd" was generated
+    boolean found = false;
+    Path testSMT = null;
+    for (Path file : outputFiles) {
+      String filename = file.getFileName().toString();
+      if (filename.equals("test.smt2")) {
+        found = true;
+        testSMT = file;
+        break;
+      }
+    }
+    assertTrue("output product 'test.smt2' not found", found);
+  }
+  
+  @Test
+  public void testORSchematic() throws SchematicException, IOException {
+ // Connect two inputs through an OR gate to an output.
+    Schematic schematic = UtilSchematicConstruction
+        .instantiateSchematic("test");
+    NodeValue in0 = UtilSchematicConstruction.instantiateInputPin();
+    schematic.addNode("in0", in0);
+    NodeValue in1 = UtilSchematicConstruction.instantiateInputPin();
+    schematic.addNode("in1", in1);
+    NodeValue or0 = UtilSchematicConstruction.instantiateOr();
+    schematic.addNode("or0", or0);
+    NodeValue out0 = UtilSchematicConstruction.instantiateOutputPin();
+    schematic.addNode("out0", out0);
+    ConnectionValue net0 = UtilSchematicConstruction.instantiateWire(
+        in0.getPort("out"), or0.getPort("in0"));
+    schematic.addConnection("net0", net0);
+    ConnectionValue net1 = UtilSchematicConstruction.instantiateWire(
+        in1.getPort("out"), or0.getPort("in1"));
+    schematic.addConnection("net1", net1);
+    ConnectionValue net2 = UtilSchematicConstruction.instantiateWire(
+        or0.getPort("out"), out0.getPort("in"));
+    schematic.addConnection("net2", net2);
+
+    List<String> testLines = schematicToSMT2(schematic, 0);
+    
+    // look for declarations of all the following:
+    // in0__0, in1__0, out0__0
+    
+    int matchesIn0 = countMatches(testLines, "declare-fun\\s+in0__0");
+    assertEquals("in0__0 not declared or multiply declared", 1, matchesIn0);
+    int matchesIn1 = countMatches(testLines, "declare-fun\\s+in1__0");
+    assertEquals("in1__0 not declared or multiply declared", 1, matchesIn1);
+    int matchesOut0 = countMatches(testLines, "declare-fun\\s+out0__0");
+    assertEquals("out0__0 not declared or multiply declared", 1, matchesOut0);
+    
+  }
+  
+}


### PR DESCRIPTION
The motivation for this PR dates allllll the way back to when we first conceived of this project, and wanted to make a high-level language for digital hardware design -- one of the ideas was to generate a formal model for the design so that it could be verified and checked automatically. With this PR, we finally have code generation that can produce these models (even though we have long since diverged from the original target :grinning:)

This adds a new class called `SMT2CodeGenerator`, which takes a schematic and outputs code in the SMT-LIBv2 format. This format allows us to make statements about operations on bit-vectors and arrays, which in turn allows us to translate our hardware to a set of assertions regarding the values of these variables. The code can then be given to an SMT solver such as [STP](http://github.com/stp/stp), which will solve for unknown variables and either find a satisfying model (assignments of variables that make all assertions true) or report that the instance is unsatisfiable.

One note is that SMT-LIBv2 is effectively a pure functional language. To represent the state of objects such as registers, the code generator effectively makes a number of copies of the entire model, one for each clock cycle that is being simulated. We model the action of registers as equations/assertions across two consecutive time steps, e.g. `assert out(t) = in(t-1)`. The number of clock cycles to be simulated is specified as an input parameter to the code generator.
